### PR TITLE
Update syllabus with answer key for defense+automation lesson

### DIFF
--- a/_includes/dc/syllabus.html
+++ b/_includes/dc/syllabus.html
@@ -52,6 +52,7 @@
       <li>Materials: <a
   href="https://github.com/Duke-GCB/scicomp-python/releases/download/2023-08-24/defense_automation.zip">defense_automation.zip</a></li>
       <li><a href="https://github.com/Duke-GCB/scicomp-python/releases/download/2023-08-24/2023-08-24.Defense-Automation.pptx">Lesson overview</a></li>
+      <li><a href="https://github.com/Duke-GCB/scicomp-python/blob/e38040f31744f257c312b40e42503fd5ab181c2f/automation_python_instructor.ipynb">Answers for the Python notebook exercises</a></li>
     </ul>
   </div>
   <div class="col-md-4">


### PR DESCRIPTION
Updated the syllabus to include the instructor notebook (answer key) for the defense+automation lesson, so the students have it after the workshop ends.